### PR TITLE
fix: fix missing translateY prop

### DIFF
--- a/src/SharedElementRenderer.js
+++ b/src/SharedElementRenderer.js
@@ -59,10 +59,11 @@ class SharedElementRenderer extends PureComponent {
 
     if (!isNaN(source.position.pageY)) {
       translateYValue = new Animated.Value(source.position.pageY);
-      this.setState({ translateYValue });
     }
 
     if (source.position.pageY !== destination.position.pageY) {
+      this.setState({ translateYValue });
+
       animations.push(
         Animated.timing(translateYValue, {
           toValue: destination.position.pageY,

--- a/src/SharedElementRenderer.js
+++ b/src/SharedElementRenderer.js
@@ -55,11 +55,14 @@ class SharedElementRenderer extends PureComponent {
     const { source, destination } = element;
 
     const animations = [];
+    let translateYValue = 0;
 
-    if (source.position.pageY && destination.position.pageY) {
-      const translateYValue = new Animated.Value(source.position.pageY);
+    if (!isNaN(source.position.pageY)) {
+      translateYValue = new Animated.Value(source.position.pageY);
       this.setState({ translateYValue });
+    }
 
+    if (source.position.pageY !== destination.position.pageY) {
       animations.push(
         Animated.timing(translateYValue, {
           toValue: destination.position.pageY,

--- a/src/SharedElementRenderer.js
+++ b/src/SharedElementRenderer.js
@@ -56,7 +56,7 @@ class SharedElementRenderer extends PureComponent {
 
     const animations = [];
 
-    if (source.position.pageY !== destination.position.pageY) {
+    if (source.position.pageY && destination.position.pageY) {
       const translateYValue = new Animated.Value(source.position.pageY);
       this.setState({ translateYValue });
 


### PR DESCRIPTION
Hi. Keep doing the good work. There is, however, a minor glitch I have encountered
on several devices when trying your lib. TranslateY prop is often
undefined. You can easily reproduce it even on your demo by pressing the
very **first** list item -> transition is often bumpy as the cloned element misses
translateY value. It holds true even when coming back from the detail
page into the list view. By introducing this minor change, the transition
animation is butter-smooth with no more unpleasant jumpy behavior as a result of a missing/undefined value. Thx for your consideration.