### PR TITLE
fix: removed Math from Math.isNaN - Math is undefined

### DIFF
--- a/src/SharedElementRenderer.js
+++ b/src/SharedElementRenderer.js
@@ -57,7 +57,7 @@ class SharedElementRenderer extends PureComponent {
     const animations = [];
     let translateYValue = 0;
 
-    if (!Math.isNaN(source.position.pageY)) {
+    if (!isNaN(source.position.pageY)) {
       translateYValue = new Animated.Value(source.position.pageY);
     }
 


### PR DESCRIPTION
When testing with react-native-motion-playground when initiating the animation the error Math is undefined was thrown. "isNaN" is a global method in javascript and can be accessed directly. 
I have tested on Android and iOS.

See
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN