### PR TITLE
fix(SharedElement): return callback(null) when no ref is found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workspace: &workspace
 node_config: &node_config
     working_directory: *workspace
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:lts
 
 # Key to cache gradle dependecies
 yarn_key: &yarn_key

--- a/src/SharedElement.js
+++ b/src/SharedElement.js
@@ -190,7 +190,7 @@ class SharedElement extends PureComponent {
   };
   measure = (ref, callback) => {
     if (!ref) {
-      callback(null);
+      return callback(null);
     }
 
     ref.measure((x, y, width, height, pageX, pageY) => {

--- a/src/SharedElement.js
+++ b/src/SharedElement.js
@@ -190,7 +190,8 @@ class SharedElement extends PureComponent {
   };
   measure = (ref, callback) => {
     if (!ref) {
-      return callback(null);
+      callback(null);
+      return;
     }
 
     ref.measure((x, y, width, height, pageX, pageY) => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49735096/88395229-1ee06680-cd97-11ea-87b5-15f6cc2f9eb5.png)

Sometimes I'd got this error when transitioning trough animations, so my colleague @robcoutinho found that maybe it wasn't being treated right when no reference was found on `measure` method.
I've tested it with this modification on my branch and since then I had no more error in my app! By simply returning this callback when no reference is found.